### PR TITLE
remove extra lines

### DIFF
--- a/scripts/linux/setup-env.sh
+++ b/scripts/linux/setup-env.sh
@@ -6,10 +6,8 @@ sudo mkdir -p /opt/<%= appName %>/config/certs
 sudo mkdir -p /opt/<%= appName %>/tmp
 sudo mkdir -p /opt/mongodb
 
-sudo mkdir -p /etc/nginx/
 sudo mkdir -p /etc/nginx/vhost.d
 sudo mkdir -p /etc/nginx/conf.d
-sudo mkdir -p /usr/share/nginx
 sudo mkdir -p /usr/share/nginx/html
 
 sudo chown ${USER} /opt/<%= appName %> -R


### PR DESCRIPTION
There is no need to create directory /a and then /a/b, while using `mkdir -p`
pls refer to http://man7.org/linux/man-pages/man1/mkdir.1.html
