### PR TITLE
Update README.md w/ multiple domain example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ To automatically get and renew Let's encrypt certificates for your app you will 
 }
 ```
 
+To configure a SAN certificate for multiple domains list the base domain first and separate each additional subdomain with only a comma:
+
+```js
+"letsEncrypt": {
+  "domain": "myapp.com,www.myapp.com,mmm.myapp.com",
+  "email": "johndoe@myapp.com"
+}
+```
+
 If you're updating your existing project first you will need to update your setup environment:
 
     mupx-letsencrypt setup


### PR DESCRIPTION
Added a section to the readme with an example configuration for generating a SAN certificate (multi-domain certificate).  