### PR TITLE
Fix: Updated archiver to 1.x.x to avoid crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,16 @@
   "version": "1.1.1",
   "description": "Meteor Deployments with Let's Encrypt support",
   "dependencies": {
+    "archiver": "1.x.x",
     "async": "^0.9.0",
     "cjson": "0.3.x",
     "colors": "0.6.x",
+    "minimist": "1.1.1",
     "nodemiral": "^1.0.1",
     "rimraf": "2.x.x",
     "underscore": "1.7.0",
-    "uuid": "1.4.x",
-    "archiver": "0.14.x",
     "update-notifier": "0.4.x",
-    "minimist": "1.1.1"
+    "uuid": "1.4.x"
   },
   "bin": {
     "mupx-letsencrypt": "./bin/mup"


### PR DESCRIPTION
https://github.com/zodern/meteor-up/issues/113 becomes an issue after upgrading to Node 6.